### PR TITLE
Updates and fixes for xfce4-check-update.py

### DIFF
--- a/xfce4-check-update.py
+++ b/xfce4-check-update.py
@@ -24,17 +24,17 @@ from distutils.version import StrictVersion
 #####################################################
 
 categories = ['apps/', 'panel-plugins/', 'thunar-plugins/', 'xfce/']
-base_url = 'http://archive.xfce.org/src/'
+base_url = 'https://archive.xfce.org/src/'
 
 def get_links(link):
         pars = BeautifulSoup(urllib.request.urlopen(base_url+link),
                 features='lxml')
-        link = pars.body.find('table').find_all('a', href=True)
+        link = pars.body.find_all('a', href=True)
         return link
     
 def filter_links(links):
         l = list(filter(lambda x: 
-            x['href'] not in ['/src/', '?C=N;O=D', '?C=M;O=A', '?C=S;O=A']
+            x['href'] not in ['/src/', '?C=N;O=D', '?C=M;O=A', '?C=S;O=A', '../']
             and x.text != ''
             and x.text != 'Parent Directory', links))
         l.sort(key=lambda x: x.text)

--- a/xfce4-check-update.py
+++ b/xfce4-check-update.py
@@ -15,7 +15,7 @@ import re
 import pprint
 import sys
 from bs4 import BeautifulSoup
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion, StrictVersion
 
 #####################################################
 #                                                   #
@@ -60,6 +60,9 @@ def get_project_last_version(project):
         except IndexError: return # empty project
 
         files_versions = get_sublinks(last_version)
+        # StrictVersion doesn't handle version strings with four separate parts.
+        files_versions.sort(key=lambda x: LooseVersion(re.search('\-([\d\.]+)\.',
+                                                                 x.split("/")[3])[1]))
         return files_versions[-1]
 
 def get_upstream_versions():
@@ -135,7 +138,8 @@ for name,up in upstream.items():
             lv = re.sub(r'nb[0-9]+', ' ', local).strip()
             tv = up.split('/')[-1].split('-')[-1].split('.')
             uv = '.'.join(tv[:len(tv)-2])
-            try : needsupdated = StrictVersion(lv) < StrictVersion(uv)
+            # StrictVersion doesn't handle version strings with four separate parts.
+            try : needsupdated = LooseVersion(lv) < LooseVersion(uv)
             except: needsupdated = False
             print(name + ' , ' + lv + ' , ' + uv + ' , ' +
                     ('yes' if needsupdated else 'no') + ',')


### PR DESCRIPTION
Hi Youri,

I've updated xfce4-check-update.py to reflect changes to the Xfce.org website (e.g. no table elements are used now), and to fix detecting the latest version in some cases. Further details are in the commit messages of each.

(I haven't looked at the MATE script yet. Also, this change exposed another, separate bug with one edge case: xfce4-gvfs-mount has a hash ID element in its version that this doesn't handle, but that's just one package.)

Regards,

Dave