### PR TITLE
mate-check-update.py: fix stripping of PKGREVISION values

### DIFF
--- a/mate-check-update.py
+++ b/mate-check-update.py
@@ -131,10 +131,10 @@ versions = get_pkgsrc_version()
 for name,uv in versions.items():
     lv = get_upstream_version(mate_release, name)
     # extract versions, we expect two extension archives
-    lv = re.sub(r'nb[0-9]+', ' ', lv).strip()
+    uv = re.sub(r'nb[0-9]+', ' ', uv).strip()
     try : needsupdated = StrictVersion(lv) > StrictVersion(uv)
     except: needsupdated = False
     print(name + ' , ' + uv + ' , ' + lv + ' , ' +
             ('yes' if needsupdated else 'no'))
 print('Done...', file=sys.stderr)
-print('Dont forget to check mate-themes: http://pub.mate-desktop.org/releases/themes/, pkgsrc version is ' + get_package_version('mate-theme'), file=sys.stderr)
+print('Don\'t forget to check mate-themes: http://pub.mate-desktop.org/releases/themes/, pkgsrc version is ' + get_package_version('mate-theme'), file=sys.stderr)


### PR DESCRIPTION
Strip PKGREVISION strings from the variable that represents the pkgsrc
version number, not the upstream version.

Before:

mate-panel , 1.24.0nb2 , 1.24.1 , no

After:

mate-panel , 1.24.0 , 1.24.1 , yes

(The meanings of the variables "lv" and "uv" are reversed versus
the same names in xfce4-check-update.py. I kept their use internally
consistent here, to minimize the diff in this change. But it is
potentially confusing.)