### PR TITLE
mate-check-update.py: add a missing package

### DIFF
--- a/mate-check-update.py
+++ b/mate-check-update.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.7
+#!/usr/bin/env python3.10
 
 
 #####################################################
@@ -68,6 +68,7 @@ packages = ["atril",
         "engrampa",
         "eom",
         "libmatekbd",
+        "libmatemixer",
         "libmateweather",
         "marco",
         "mate-applets",


### PR DESCRIPTION
Add libmatemixer. (While here, also bump the expected Python version to the current pkgsrc default.)